### PR TITLE
Fix trailing slashes in meta image URLs

### DIFF
--- a/26.html
+++ b/26.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://twitter.com/nathanbenaich/status/1395417457951711239?s=20" />
     </head>

--- a/404.html
+++ b/404.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="A VC firm investing in AI-first companies" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/500.html
+++ b/500.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="A VC firm investing in AI-first companies" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/FT.html
+++ b/FT.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://www.ft.com/content/fd038300-f09a-4afc-9f7d-c0e3d6965243" />
     </head>

--- a/audio.html
+++ b/audio.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://podcasters.spotify.com/pod/show/nathan-benaich" />
     </head>

--- a/berlinai.html
+++ b/berlinai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/berlinai" />
     </head>

--- a/bio.html
+++ b/bio.html
@@ -49,7 +49,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://nathanbenaich.substack.com/p/6-impactful-applications-of-ai-to-the-life-sciences-new-essay-150757" />
     </head>

--- a/blog/26.html
+++ b/blog/26.html
@@ -48,7 +48,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://twitter.com/nathanbenaich/status/1395417457951711239?s=20" />
     </head>

--- a/blog/500.html
+++ b/blog/500.html
@@ -49,7 +49,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="A VC firm investing in AI-first companies" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/blog/6-areas-of-AI-research-to-watch-closely.html
+++ b/blog/6-areas-of-AI-research-to-watch-closely.html
@@ -57,7 +57,7 @@
     <meta property="og:url" content="https://www.airstreet.com/blog-6-areas-of-ai-research-to-watch" />
     <meta property="og:title" content="6 areas of AI to watch" />
     <meta property="og:description" content="A popular essay on particularly noteworthy techniques that are likely to impact the future of digital products and services, why they are important and who is driving innovation for each." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/AI-first-biology.html
+++ b/blog/AI-first-biology.html
@@ -57,12 +57,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="AI-first biology" />
     <meta property="twitter:description" content="We explain why the AI moment for biology is here and how AI-first biology startups can capture value." />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/ai-first-biology-cover-resized.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/ai-first-biology-cover-resized.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/ai-first-biology" />
     <meta property="og:title" content="AI-first biology" />
     <meta property="og:description" content="I explain why the AI moment for biology is here and how AI-first biology startups can capture value." />
-    <meta property="og:image" content="https://www.airstreet.com/blog/ai-first-biology-cover-resized.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/ai-first-biology-cover-resized.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/RAAIS-2020.html
+++ b/blog/RAAIS-2020.html
@@ -57,12 +57,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="10 AI talks from RAAIS 2020" />
     <meta property="twitter:description" content="10 talks on building AI-first products and new AI research" />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/raais-2020.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/raais-2020.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/raais-2020" />
     <meta property="og:title" content="10 AI talks from RAAIS 2020" />
     <meta property="og:description" content="10 talks on building AI-first products and new AI research" />
-    <meta property="og:image" content="https://www.airstreet.com/blog/raais-2020.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/raais-2020.png">
     <meta property="og:type" content="article" />
 
 

--- a/blog/The-full-stack-machine-learning-startup.html
+++ b/blog/The-full-stack-machine-learning-startup.html
@@ -56,12 +56,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="The full-stack ML company" />
     <meta property="twitter:description" content="We make the case for operating as a “full-stack ML company” in order to maximize economic value capture." />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/full-stack-ml-cover.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/full-stack-ml-cover.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/full-stack-ml-cover" />
     <meta property="og:title" content="The full-stack ML company" />
     <meta property="og:description" content="We make the case for operating as a “full-stack ML company” in order to maximize economic value capture." />
-    <meta property="og:image" content="https://www.airstreet.com/blog/full-stack-ml-cover.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/full-stack-ml-cover.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/index.html
+++ b/blog/index.html
@@ -57,7 +57,7 @@
     <meta property="og:url" content="https://www.airstreet.com/" />
     <meta property="og:title" content="Air Street Capital blog" />
     <meta property="og:description" content="The AI-first playbook for technology and life science companies" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/index2.html
+++ b/blog/index2.html
@@ -58,7 +58,7 @@
     <meta property="og:url" content="https://www.airstreet.com/" />
     <meta property="og:title" content="Air Street Capital blog" />
     <meta property="og:description" content="The AI-first playbook for technology and life science companies" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/openmined-pricon-2020.html
+++ b/blog/openmined-pricon-2020.html
@@ -58,12 +58,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="Building privacy-preserving, AI-first software products: A talk at OpenMined Privacy Conference 2020" />
     <meta property="twitter:description" content="Building privacy-preserving, AI-first software products: A talk at OpenMined Privacy Conference 2020" />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/openmined-pricon-2020.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/openmined-pricon-2020.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/openmined-pricon-2020" />
     <meta property="og:title" content="Building privacy-preserving, AI-first software products: A talk at OpenMined Privacy Conference 2020" />
     <meta property="og:description" content="Building privacy-preserving, AI-first software products: A talk at OpenMined Privacy Conference 2020" />
-    <meta property="og:image" content="https://www.airstreet.com/blog/openmined-pricon-2020.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/openmined-pricon-2020.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/spinouts.html
+++ b/blog/spinouts.html
@@ -57,12 +57,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="Rewriting the European spinout playbook" />
     <meta property="twitter:description" content="Instead of encouraging innovation, universities treat would-be founders as ‘problem children’" />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/spinouts-cover.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/spinouts-cover.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/spinouts" />
     <meta property="og:title" content="Rewriting the European spinout playbook" />
     <meta property="og:description" content="Instead of encouraging innovation, institutions treat would-be founders as ‘problem children’" />
-    <meta property="og:image" content="https://www.airstreet.com/blog/spinouts-cover.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/spinouts-cover.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/test-blog.html
+++ b/blog/test-blog.html
@@ -57,12 +57,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="👋 Welcome to Air Street Capital" />
     <meta property="twitter:description" content="We've raised a $17M fund to back early-stage “AI-native” founders building for the enterprise, consumer and life sciences." />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/welcome-to-air-street-capital" />
     <meta property="og:title" content="👋 Welcome to Air Street Capital" />
     <meta property="og:description" content="We've raised a $17M fund to back early-stage “AI-native” founders building for the enterprise, consumer and life sciences." />
-    <meta property="og:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/blog/welcome-to-air-street-capital.html
+++ b/blog/welcome-to-air-street-capital.html
@@ -57,12 +57,12 @@
     <meta name="twitter:creator" content="@airstreet" />
     <meta property="twitter:title" content="👋 Welcome to Air Street Capital" />
     <meta property="twitter:description" content="We've raised a $17M fund to back early-stage “AI-native” founders building for the enterprise, consumer and life sciences." />
-    <meta property="twitter:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png/">
+    <meta property="twitter:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png">
     <!-- for linkedin -->
     <meta property="og:url" content="https://www.airstreet.com/blog/welcome-to-air-street-capital" />
     <meta property="og:title" content="👋 Welcome to Air Street Capital" />
     <meta property="og:description" content="We've raised a $17M fund to back early-stage “AI-native” founders building for the enterprise, consumer and life sciences." />
-    <meta property="og:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png/">
+    <meta property="og:image" content="https://www.airstreet.com/blog/welcome-to-air-street-capital.png">
     <meta property="og:type" content="article" />
     <!-- Added to have cool social share buttons -->
     <!-- Bulma-Social -->

--- a/community.html
+++ b/community.html
@@ -51,7 +51,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re hiring a Community Lead, join us!" />
-        <meta property="og:image" content="https://www.airstreet.com/community.png/">
+        <meta property="og:image" content="https://www.airstreet.com/community.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://docs.google.com/document/d/1odnaI8QZ_ZYjim9Zwyb8iYLd1Arr-BIhVnT2PP-4u0A/edit" />
     </head>

--- a/content231933t2q00j.html
+++ b/content231933t2q00j.html
@@ -53,7 +53,7 @@
     <meta property="og:url" content="https://www.airstreet.com/content12lk1n2r1 " />
     <meta property="og:title" content="State of AI Report, AI newsletter, AI-first playbook" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/defense.html
+++ b/defense.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://www.airstreet.com/blog/european-defense-procurement" />
     </head>

--- a/depracated/community10928419085195.html
+++ b/depracated/community10928419085195.html
@@ -56,7 +56,7 @@
     <meta property="og:url" content="https://www.airstreet.com/content" />
     <meta property="og:title" content="Join our RAAIS and London.AI community" />
     <meta property="og:description" content="We’re home to thousands of entrepreneurs, operators, and researchers focused on the science and applications of AI technology." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/depracated/content231933t2q00j.html
+++ b/depracated/content231933t2q00j.html
@@ -56,7 +56,7 @@
     <meta property="og:url" content="https://www.airstreet.com/content12lk1n2r1 " />
     <meta property="og:title" content="State of AI Report, AI newsletter, AI-first playbook" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/depracated/focus12109509jnk.html
+++ b/depracated/focus12109509jnk.html
@@ -56,7 +56,7 @@
     <meta property="og:url" content="https://www.airstreet.com/focus" />
     <meta property="og:title" content="The founders we seek" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/depracated/indexlkasdlfnasldkku4.html
+++ b/depracated/indexlkasdlfnasldkku4.html
@@ -56,7 +56,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="A VC firm investing in AI-first companies" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/depracated/teamlkansdgiolwkenat.html
+++ b/depracated/teamlkansdgiolwkenat.html
@@ -56,7 +56,7 @@
     <meta property="og:url" content="https://www.airstreet.com/team" />
     <meta property="og:title" content="The Air Street team" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/events.html
+++ b/events.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/airstreet" />
     </head>

--- a/fellowships.html
+++ b/fellowships.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://airstreet.typeform.com/to/STxMgb" />
     </head>

--- a/focus12109509jnk.html
+++ b/focus12109509jnk.html
@@ -53,7 +53,7 @@
     <meta property="og:url" content="https://www.airstreet.com/focus" />
     <meta property="og:title" content="The founders we seek" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/fortune.html
+++ b/fortune.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://fortune.com/2020/10/30/air-street-ai-artificial-intelligence-venture-fund-twitter-supercell-google/" />
     </head>

--- a/fullstack.html
+++ b/fullstack.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://www.nathanbenaich.com/blog/the-full-stack-machine-learning-startup" />
     </head>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="A VC firm investing in AI-first companies" />
     <meta property="og:description" content="AI-first companies are all you need" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/intel.html
+++ b/intel.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://press.airstreet.com/p/vibe-shifts-1-intel" />
     </head>

--- a/londonai.html
+++ b/londonai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/londonai" />
     </head>

--- a/merch.html
+++ b/merch.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://airstreet.typeform.com/to/eO1nx5pk" />
     </head>

--- a/moat.html
+++ b/moat.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://press.airstreet.com/p/being-first-is-a-moat" />
     </head>

--- a/munichai.html
+++ b/munichai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/munichai" />
     </head>

--- a/newsletter.html
+++ b/newsletter.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://nathanbenaich.substack.com/" />
     </head>

--- a/nycai.html
+++ b/nycai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/nycai" />
     </head>

--- a/parisai.html
+++ b/parisai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/parisai" />
     </head>

--- a/portfolio.html
+++ b/portfolio.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com/portfolio" />
     <meta property="og:title" content="Air Street Capital portfolio companies" />
     <meta property="og:description" content="AI-first SaaS, dev tools, infra, defense, techbio et al." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/shop/eu.html
+++ b/shop/eu.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="Shop Air Street Capital (Europe)" />
     <meta property="og:description" content="T-shirts, hoodies, stickers and more" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/shop/index.html
+++ b/shop/index.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="Shop Air Street Capital merch" />
     <meta property="og:description" content="T-shirts, hoodies, stickers and more" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/shop/us.html
+++ b/shop/us.html
@@ -51,7 +51,7 @@
     <meta property="og:url" content="https://www.airstreet.com" />
     <meta property="og:title" content="Shop Air Street Capital (USA)" />
     <meta property="og:description" content="T-shirts, hoodies, stickers and more" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/slack.html
+++ b/slack.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://join.slack.com/t/airstreetcommunity/shared_invite/zt-35ca555dt-aEYKVo6vE8XNmzsF6Ac_rQ" />
     </head>

--- a/soai.html
+++ b/soai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/soai" />
     </head>

--- a/spinout.html
+++ b/spinout.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://press.airstreet.com/p/rewriting-the-european-spinout-playbook" />
     </head>

--- a/spinouts.html
+++ b/spinouts.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://press.airstreet.com/p/rewriting-the-european-spinout-playbook" />
     </head>

--- a/summit.html
+++ b/summit.html
@@ -49,7 +49,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://www.raais.co" />
     </head>

--- a/team.html
+++ b/team.html
@@ -52,7 +52,7 @@
     <meta property="og:url" content="https://www.airstreet.com/team" />
     <meta property="og:title" content="The Air Street team" />
     <meta property="og:description" content="AI-first companies are all you need" />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/teamOLD.html
+++ b/teamOLD.html
@@ -53,7 +53,7 @@
     <meta property="og:url" content="https://www.airstreet.com/team" />
     <meta property="og:title" content="The Air Street team" />
     <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-    <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+    <meta property="og:image" content="https://www.airstreet.com/logo.png">
     <meta property="og:type" content="article" />
 </head>
 

--- a/zurichai.html
+++ b/zurichai.html
@@ -50,7 +50,7 @@
         <meta property="og:url" content="https://www.airstreet.com" />
         <meta property="og:title" content="A VC firm investing in AI-first startups" />
         <meta property="og:description" content="We’re a partnership of investors, engineering leaders, technology entrepreneurs and AI researchers investing in AI-first companies." />
-        <meta property="og:image" content="https://www.airstreet.com/logo.png/">
+        <meta property="og:image" content="https://www.airstreet.com/logo.png">
         <meta property="og:type" content="article" />
         <meta http-equiv="Refresh" content="0; url=https://lu.ma/zurichai" />
     </head>


### PR DESCRIPTION
## Summary
- remove stray slashes after `logo.png` and other images in Open Graph and Twitter tags

## Testing
- `grep -R "\.png/" --exclude-dir=.git -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_683f4a89250c832684eefca9283a7e27