### PR TITLE
Remove Guy Kendall from team page

### DIFF
--- a/team.html
+++ b/team.html
@@ -180,7 +180,6 @@
                 <ul>
                 <li><a href="https://www.linkedin.com/in/nathanbenaich/">Nathan Benaich</a> Solo Member of Investment Staff</li>
                 <li><a href="https://www.linkedin.com/in/paulapastor/">Paula Pastor Castaño</a> Advisor, Legal & Operations</li>
-                <li><a href="https://www.linkedin.com/in/guykendall">Guy Kendall</a> Head of Talent</li>
                 </ul>
 
                 <br>


### PR DESCRIPTION
## Summary
- Remove Guy Kendall (Head of Talent) from the Team list on `team.html`

## Test plan
- [ ] Open `team.html` in a browser and confirm Guy Kendall no longer appears under Team

https://claude.ai/code/session_017spyr3uDtccHzSSdb2YSoi

---
_Generated by [Claude Code](https://claude.ai/code/session_017spyr3uDtccHzSSdb2YSoi)_