### PR TITLE
Portfolio: announce Perceptic

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -189,7 +189,7 @@
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. AI infra (FR);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Defense (EU);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Ambient AI (US);</li>
-            <li><a href="###" target="_blank" rel="noopener noreferrer"><b>Unannounced</b></a>. AI for science (UK);</li>
+            <li><a href="https://www.perceptic.com/" target="_blank" rel="noopener noreferrer">Perceptic</a>. Agents for drug discovery (UK);</li>
             <li><a href="https://www.synthesia.io/" target="_blank" rel="noopener noreferrer">Synthesia</a>. AI video (UK);</li>
             <li><a href="https://bfl.ai/" target="_blank" rel="noopener noreferrer">Black Forest Labs</a>. Visual intelligence (DE);</li>
         </ul>


### PR DESCRIPTION
Updates the Epoch III portfolio entry: the unannounced "AI for science (UK)" company is now live as **Perceptic** (ex-Palantir founders, AI OS for drug development).

- Linked to https://www.perceptic.com/ (verified 200, live site)
- Tagline: "Agents for drug discovery (UK)"
- Removed bold/`###` placeholder to match the other announced entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)