### PR TITLE
Update Epoch III portfolio entries

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -186,8 +186,9 @@
 <div class="container has-text portfolio">
     <h1>Epoch III ('25-)</h1>
         <ul>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. AI infra (FR);</li>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Defense (EU);</li>
+            <li><a href="###" target="_blank" rel="noopener noreferrer">Alta Ares</a>. Air defense (FR);</li>
+            <li><a href="https://www.macrodata.co/" target="_blank" rel="noopener noreferrer">Macrodata</a>. AI infra (FR);</li>
+            <li><a href="###" target="_blank" rel="noopener noreferrer">Onodrim</a>. Defense (EU);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Ambient AI (US);</li>
             <li><a href="https://www.perceptic.com/" target="_blank" rel="noopener noreferrer">Perceptic</a>. Agents for drug discovery (UK);</li>
             <li><a href="https://www.synthesia.io/" target="_blank" rel="noopener noreferrer">Synthesia</a>. AI video (UK);</li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -188,7 +188,7 @@
         <ul>
             <li><a href="https://www.altaares.com/" target="_blank" rel="noopener noreferrer">Alta Ares</a>. Air defense (FR);</li>
             <li><a href="https://www.macrodata.co/" target="_blank" rel="noopener noreferrer">Macrodata</a>. AI infra (FR);</li>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Onodrim</a>. Defense (EU);</li>
+            <li><a href="https://www.onodrim.com/" target="_blank" rel="noopener noreferrer">Onodrim</a>. Defense (EU);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Ambient AI (US);</li>
             <li><a href="https://www.perceptic.com/" target="_blank" rel="noopener noreferrer">Perceptic</a>. Agents for drug discovery (UK);</li>
             <li><a href="https://www.synthesia.io/" target="_blank" rel="noopener noreferrer">Synthesia</a>. AI video (UK);</li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -186,7 +186,7 @@
 <div class="container has-text portfolio">
     <h1>Epoch III ('25-)</h1>
         <ul>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Alta Ares</a>. Air defense (FR);</li>
+            <li><a href="https://www.altaares.com/" target="_blank" rel="noopener noreferrer">Alta Ares</a>. Air defense (FR);</li>
             <li><a href="https://www.macrodata.co/" target="_blank" rel="noopener noreferrer">Macrodata</a>. AI infra (FR);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Onodrim</a>. Defense (EU);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Ambient AI (US);</li>


### PR DESCRIPTION
Updates the Epoch III ('25-) section of the portfolio page:

- **Added** a new top entry: Alta Ares — Air defense (FR)
- **Renamed** the AI infra (FR) entry from "Unannounced" to **Macrodata**, linking to https://www.macrodata.co/
- **Renamed** the Defense (EU) entry from "Unannounced" to **Onodrim** (link left as placeholder — no URL provided)

https://claude.ai/code/session_017dHEv56ZMDPTqGFMQ6ehP2

---
_Generated by [Claude Code](https://claude.ai/code/session_017dHEv56ZMDPTqGFMQ6ehP2)_