### PR TITLE
Name GTV in Epoch II portfolio

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -202,7 +202,7 @@
             <li><a href="https://kradle.ai/" target="_blank" rel="noopener noreferrer">Kradle</a>. Frontier evals (USA);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. TechBio (EU);</li>
             <li><a href="https://www.clove.com/" target="_blank" rel="noopener noreferrer">Clove</a>. Wealth management (UK);</li>
-            <li><a href="https://www.gr.inc/" target="_blank" rel="noopener noreferrer">General Reasoning</a>. AI agents (EU);</li>
+            <li><a href="https://www.gr.inc/" target="_blank" rel="noopener noreferrer">General Reasoning</a>. Long-horizon agents (UK);</li>
             <li><a href="https://www.getgtv.com/" target="_blank" rel="noopener noreferrer">GTV</a>. AI video (USA);</li>
             <li><a href="https://www.delfa.ai/" target="_blank" rel="noopener noreferrer">Delfa</a>. Clinical trials (USA/UK);</li>
             <li><a href="https://www.polarmist.ai/" target="_blank" rel="noopener noreferrer">Polar Mist</a>. Maritime autonomy (EU);</li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -202,7 +202,7 @@
             <li><a href="https://kradle.ai/" target="_blank" rel="noopener noreferrer">Kradle</a>. Frontier evals (USA);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. TechBio (EU);</li>
             <li><a href="https://www.clove.com/" target="_blank" rel="noopener noreferrer">Clove</a>. Wealth management (UK);</li>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. AI agents (EU);</li>
+            <li><a href="https://www.gr.inc/" target="_blank" rel="noopener noreferrer">General Reasoning</a>. AI agents (EU);</li>
             <li><a href="https://www.getgtv.com/" target="_blank" rel="noopener noreferrer">GTV</a>. AI video (USA);</li>
             <li><a href="https://www.delfa.ai/" target="_blank" rel="noopener noreferrer">Delfa</a>. Clinical trials (USA/UK);</li>
             <li><a href="https://www.polarmist.ai/" target="_blank" rel="noopener noreferrer">Polar Mist</a>. Maritime autonomy (EU);</li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -199,7 +199,7 @@
 <div class="container has-text portfolio">
     <h1>Epoch II ('22-'25)</h1>
         <ul>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Frontier evals (USA);</li>
+            <li><a href="https://kradle.ai/" target="_blank" rel="noopener noreferrer">Kradle</a>. Frontier evals (USA);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. TechBio (EU);</li>
             <li><a href="https://www.clove.com/" target="_blank" rel="noopener noreferrer">Clove</a>. Wealth management (UK);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. AI agents (EU);</li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -203,7 +203,7 @@
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. TechBio (EU);</li>
             <li><a href="https://www.clove.com/" target="_blank" rel="noopener noreferrer">Clove</a>. Wealth management (UK);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. AI agents (EU);</li>
-            <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. AI video (USA);</li>
+            <li><a href="https://www.getgtv.com/" target="_blank" rel="noopener noreferrer">GTV</a>. AI video (USA);</li>
             <li><a href="https://www.delfa.ai/" target="_blank" rel="noopener noreferrer">Delfa</a>. Clinical trials (USA/UK);</li>
             <li><a href="https://www.polarmist.ai/" target="_blank" rel="noopener noreferrer">Polar Mist</a>. Maritime autonomy (EU);</li>
             <li><a href="https://atelico.studio/" target="_blank" rel="noopener noreferrer">Studio Atelico</a>. AI game studio (USA/UK);</li>


### PR DESCRIPTION
Renames the Epoch II ('22-'25) AI video (USA) entry from "Unannounced" to **GTV**, linked to https://www.getgtv.com/

https://claude.ai/code/session_017dHEv56ZMDPTqGFMQ6ehP2

---
_Generated by [Claude Code](https://claude.ai/code/session_017dHEv56ZMDPTqGFMQ6ehP2)_