### PR TITLE
Give the long-form pages readable typography

### DIFF
--- a/10-best-ai-strategies-that-will-transform-your-business-2025.html
+++ b/10-best-ai-strategies-that-will-transform-your-business-2025.html
@@ -198,7 +198,7 @@
                     <p class="copy">Air Street Capital is a venture capital firm investing in AI-first technology and life science companies in Europe and the US. We invest as early as possible and enjoy iterating through product, market and technology strategy from day 0. Our common goal is to create enduring companies that make a lasting impact on their markets.</p>
             <br>
           </div> -->
-     <div class="container has-text portfolio">
+     <div class="container portfolio longform">
       <h1>
        10 Best AI Strategies That Will Transform Your Business in 2025
       </h1>

--- a/12-best-ai-venture-capital-firms-transforming-technology-and-artificial-intelligence-in-2025.html
+++ b/12-best-ai-venture-capital-firms-transforming-technology-and-artificial-intelligence-in-2025.html
@@ -198,7 +198,7 @@
                     <p class="copy">Air Street Capital is a venture capital firm investing in AI-first technology and life science companies in Europe and the US. We invest as early as possible and enjoy iterating through product, market and technology strategy from day 0. Our common goal is to create enduring companies that make a lasting impact on their markets.</p>
             <br>
           </div> -->
-     <div class="container has-text portfolio">
+     <div class="container portfolio longform">
       <h1>
        12 Best AI Venture Capital Firms Transforming Tech in 2025
       </h1>
@@ -221,9 +221,105 @@
       <p>
        These firms are ordered alphabetically, not ranked. Selection criteria include portfolio signal, stage consistency, and technical diligence rigor. Check sizes are directional ranges and vary by opportunity.
       </p>
-      <p>
-       FirmStage FocusSectorsCheck Size RangeLead/Co-LeadAir Street CapitalPre-seed to Series AEnterprise, Bio, Defense$1-15MLead/Co-leadAccelSeed to Series AEnterprise, Consumer$5-25MLeadAndreessen HorowitzMulti-stageEnterprise, Consumer, Infra$10-100M+LeadDCVCSeed to Series BDeep-tech, Climate$5-30MLeadFounders FundSeed to GrowthAll sectors$10-100MLeadGeneral CatalystSeed to GrowthHealthcare, Enterprise$5-50MLeadKhosla VenturesSeed to GrowthDeep-tech, Bio, Robotics$5-50MLeadLightspeedSeed to GrowthEnterprise, Infra$5-75MLeadM12Series A+Enterprise, Infra$10-50MCo-leadRadical VenturesSeed to Series BAI-first$2-25MLeadSapphire VenturesSeries A+Enterprise$10-50MLead/Co-leadSequoia CapitalMulti-stageAll sectors$1-100M+Lead
-      </p>
+      <div class="table-scroll">
+       <table>
+        <thead>
+         <tr>
+          <th>Firm</th>
+          <th>Stage Focus</th>
+          <th>Sectors</th>
+          <th>Check Size Range</th>
+          <th>Lead/Co-Lead</th>
+         </tr>
+        </thead>
+        <tbody>
+         <tr>
+          <td>Air Street Capital</td>
+          <td>Pre-seed to Series A</td>
+          <td>Enterprise, Bio, Defense</td>
+          <td>$1-15M</td>
+          <td>Lead/Co-lead</td>
+         </tr>
+         <tr>
+          <td>Accel</td>
+          <td>Seed to Series A</td>
+          <td>Enterprise, Consumer</td>
+          <td>$5-25M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>Andreessen Horowitz</td>
+          <td>Multi-stage</td>
+          <td>Enterprise, Consumer, Infra</td>
+          <td>$10-100M+</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>DCVC</td>
+          <td>Seed to Series B</td>
+          <td>Deep-tech, Climate</td>
+          <td>$5-30M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>Founders Fund</td>
+          <td>Seed to Growth</td>
+          <td>All sectors</td>
+          <td>$10-100M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>General Catalyst</td>
+          <td>Seed to Growth</td>
+          <td>Healthcare, Enterprise</td>
+          <td>$5-50M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>Khosla Ventures</td>
+          <td>Seed to Growth</td>
+          <td>Deep-tech, Bio, Robotics</td>
+          <td>$5-50M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>Lightspeed</td>
+          <td>Seed to Growth</td>
+          <td>Enterprise, Infra</td>
+          <td>$5-75M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>M12</td>
+          <td>Series A+</td>
+          <td>Enterprise, Infra</td>
+          <td>$10-50M</td>
+          <td>Co-lead</td>
+         </tr>
+         <tr>
+          <td>Radical Ventures</td>
+          <td>Seed to Series B</td>
+          <td>AI-first</td>
+          <td>$2-25M</td>
+          <td>Lead</td>
+         </tr>
+         <tr>
+          <td>Sapphire Ventures</td>
+          <td>Series A+</td>
+          <td>Enterprise</td>
+          <td>$10-50M</td>
+          <td>Lead/Co-lead</td>
+         </tr>
+         <tr>
+          <td>Sequoia Capital</td>
+          <td>Multi-stage</td>
+          <td>All sectors</td>
+          <td>$1-100M+</td>
+          <td>Lead</td>
+         </tr>
+        </tbody>
+       </table>
+      </div>
       <h2>
        1. Air Street Capital: AI-first early-stage investor
       </h2>

--- a/ai-specialist-vc-playbook-2025.html
+++ b/ai-specialist-vc-playbook-2025.html
@@ -185,64 +185,64 @@
             <br>
           </div> -->
 
-            <div class="container has-text portfolio">
-    <h1 class="title is-2 mb-6">How Specialist VCs Win in AI: 7 Proven Strategies [2025 Guide]</h1>
+            <div class="container portfolio longform">
+    <h1>How Specialist VCs Win in AI: 7 Proven Strategies [2025 Guide]</h1>
 
-    <p class="mb-4">In a year where AI startups captured <a href="https://pitchbook.com/news/articles/ai-startups-57-9-percent-global-venture-dollars-fear-of-missing-out-drives-up-dealmaking-q1-2025" class="has-text-link has-text-weight-semibold">57.9% of global VC dollars in Q1 2025</a>, the stakes for differentiation in venture capital have never been higher. At Air Street Capital, we believe that specialist investment firms are not only better partners to entrepreneurs building AI-first companies, they also generate better returns.</p>
+    <p>In a year where AI startups captured <a href="https://pitchbook.com/news/articles/ai-startups-57-9-percent-global-venture-dollars-fear-of-missing-out-drives-up-dealmaking-q1-2025" class="has-text-link has-text-weight-semibold">57.9% of global VC dollars in Q1 2025</a>, the stakes for differentiation in venture capital have never been higher. At Air Street Capital, we believe that specialist investment firms are not only better partners to entrepreneurs building AI-first companies, they also generate better returns.</p>
 
-    <p class="mb-4">In this playbook, we unpack <strong>seven proven strategies</strong> that enable specialist VCs to outperform—from sharper sourcing to superior insider support. Whether you're a founder evaluating term sheets or a co-investor calibrating allocation, you’ll find concrete takeaways here.</p>
+    <p>In this playbook, we unpack <strong>seven proven strategies</strong> that enable specialist VCs to outperform—from sharper sourcing to superior insider support. Whether you're a founder evaluating term sheets or a co-investor calibrating allocation, you’ll find concrete takeaways here.</p>
 
-    <h2 class="title is-3 has-text-weight-semibold mt-6 mb-4">Why Specialist VCs Outperform in AI</h2>
-    <ul class="content ml-5 mb-4">
+    <h2>Why Specialist VCs Outperform in AI</h2>
+    <ul>
       <li><strong>Superior technical insight:</strong> enables more accurate evaluation of frontier technology, models, data pipelines, and commercial opportunities.</li>
       <li><strong>Differentiated networks:</strong> unlock top-tier talent, media and customers.</li>
       <li><strong>AI-first playbook:</strong> knowledge of emerging best practices in marketing, sales, product, and technology across a cohesive portfolio of AI companies.</li>
     </ul>
-    <p class="mb-4 is-italic">Domain expertise: Deep knowledge of a specific technical or sector niche that shapes sourcing, diligence, and support.</p>
+    <p class="is-italic">Domain expertise: Deep knowledge of a specific technical or sector niche that shapes sourcing, diligence, and support.</p>
 
-    <h2 class="title is-3 has-text-weight-semibold mt-6 mb-4">Founder Preference for Deep-Tech Partners</h2>
-    <ul class="content ml-5 mb-4">
+    <h2>Founder Preference for Deep-Tech Partners</h2>
+    <ul>
       <li>Faster technical validation cycles</li>
       <li>Access to elite talent pipelines</li>
       <li>Credibility with enterprise customers</li>
     </ul>
 
-    <h2 class="title is-3 has-text-weight-semibold mt-6 mb-4">Seven Proven Strategies That Drive Outsized Returns</h2>
+    <h2>Seven Proven Strategies That Drive Outsized Returns</h2>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 1 — Own a Precise Technical Thesis Early</h3>
-    <p class="mb-4">Air Street publishes extensively to sharpen conviction and catalyze markets. For example, our <a href="https://press.airstreet.com/p/profluent-series-a" class="has-text-link">investment memo on protein language models</a> helped define a new class of biotech startup. Our coverage of <a href="https://press.airstreet.com/p/ai-first-biology" class="has-text-link">AI-native synthetic biology</a> and <a href="https://press.airstreet.com/p/scale-matters-for-biological-foundation-models" class="has-text-link">foundation models for life sciences</a> has shaped investor thinking.</p>
+    <h3>Strategy 1 — Own a Precise Technical Thesis Early</h3>
+    <p>Air Street publishes extensively to sharpen conviction and catalyze markets. For example, our <a href="https://press.airstreet.com/p/profluent-series-a" class="has-text-link">investment memo on protein language models</a> helped define a new class of biotech startup. Our coverage of <a href="https://press.airstreet.com/p/ai-first-biology" class="has-text-link">AI-native synthetic biology</a> and <a href="https://press.airstreet.com/p/scale-matters-for-biological-foundation-models" class="has-text-link">foundation models for life sciences</a> has shaped investor thinking.</p>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 2 — Run Research-Grade Technical Diligence</h3>
+    <h3>Strategy 2 — Run Research-Grade Technical Diligence</h3>
     <p class="mb-2">We know key technical experts and can validate what works, what doesn’t, and why. Our diligence process spans technical decisions and benchmark analysis. We work with advisors from academic labs, ex-FAIR/DeepMind engineers, and OSS contributors.</p>
     <p class="is-italic mb-4">Technical diligence: Rigorous evaluation of a startup’s models, data pipelines, and IP to verify feasibility and moat.</p>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 3 — Anchor With World-Class Talent Networks</h3>
-    <ul class="content ml-5 mb-4">
+    <h3>Strategy 3 — Anchor With World-Class Talent Networks</h3>
+    <ul>
       <li>DeepMind and OpenAI alumni</li>
       <li><a href="https://raais.co" class="has-text-link">RAAIS</a> and invite-only workshops</li>
       <li><a href="https://press.airstreet.com/p/raais-fellowships" class="has-text-link">RAAIS Fellowship</a> feeding technical founders</li>
     </ul>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 4 — Create Proprietary Data & Benchmarking</h3>
+    <h3>Strategy 4 — Create Proprietary Data & Benchmarking</h3>
     <p class="mb-2">Owning the data = owning the outcome. Air Street uses internal datasets on LLM training costs to evaluate and guide startups. </p>
     <p class="is-italic mb-4">Benchmarking: Systematic performance comparison across standardized tasks.</p>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 5 — Engineer Regulation Into Competitive Moats</h3>
-    <p class="mb-4">We map jurisdiction-specific AI rules, design compliance-first systems, and turn certifications into sales advantages.</p>
+    <h3>Strategy 5 — Engineer Regulation Into Competitive Moats</h3>
+    <p>We map jurisdiction-specific AI rules, design compliance-first systems, and turn certifications into sales advantages.</p>
     <p class="is-italic mb-4">Regulatory moat: Durable advantage created when compliance barriers deter less-prepared rivals.</p>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 6 — Lead Decisively</h3>
-    <ol class="content ml-5 mb-4">
+    <h3>Strategy 6 — Lead Decisively</h3>
+    <ol>
       <li>Lead when conviction is high</li>
       <li>Bring in co-investors strategically</li>
       <li>Avoid overcrowded cap tables</li>
     </ol>
 
-    <h3 class="title is-4 has-text-weight-semibold mt-6 mb-2">Strategy 7 — Compound Insight Through Follow-On</h3>
-    <p class="mb-4">We double down when market traction and technical progress hit defined milestones.</p>
+    <h3>Strategy 7 — Compound Insight Through Follow-On</h3>
+    <p>We double down when market traction and technical progress hit defined milestones.</p>
 
-    <h2 class="title is-3 has-text-weight-semibold mt-6 mb-4">Measuring Portfolio & Founder Impact</h2>
-    <ul class="content ml-5 mb-4">
+    <h2>Measuring Portfolio & Founder Impact</h2>
+    <ul>
       <li><strong>F1 score:</strong> Harmonic mean of precision and recall</li>
       <li>Inference latency</li>
       <li>Dataset growth rate</li>
@@ -250,8 +250,8 @@
       <li>Patent filings</li>
     </ul>
 
-    <h2 class="title is-3 has-text-weight-semibold mt-6 mb-4">Building the Specialist Flywheel</h2>
-    <p class="mb-4">Research, community, and capital reinforce each other. MOUs with labs, curated events like AI-first Demo Day, and GTM playbooks make it repeatable.</p>
+    <h2>Building the Specialist Flywheel</h2>
+    <p>Research, community, and capital reinforce each other. MOUs with labs, curated events like AI-first Demo Day, and GTM playbooks make it repeatable.</p>
 
     <p class="is-size-7 has-text-grey mt-6">Source for IRR data: <a href="https://publishedresearch.cambridgeassociates.com/wp-content/uploads/2014/09/Declaring-a-Major-Sector-Focused-PI-Funds.pdf" class="has-text-link">Cambridge Associates</a></p>
   </div>

--- a/ai-venture-capital.html
+++ b/ai-venture-capital.html
@@ -244,26 +244,23 @@
                     <a href="https://lu.ma/airstreet" class="button is-white is-outlined"> 🎟️ Events</a>
                     <a href="https://merch.airstreet.com/" class="button is-white is-outlined"> 🛍️ Merch</a>
                     <a href="https://www.stateof.ai/" class="button is-white is-outlined"> 👾 State of AI Report</a>
-                    <br></br>
                 </div>
 
-                <div class="tile is-parent-homepage">
-                    <article class="tile is-child box">
+                <div class="longform-wrap">
+                    <article class="longform">
 
                         <h1>About Air Street Capital</h1>
 
-                        <p class="copy">
+                        <p class="copy lead">
                             <strong>Air Street Capital is a venture capital firm investing exclusively in AI-first companies.</strong>
-                            We back companies for which advances in artificial intelligence are the primary driver of product capability, competitive advantage, and long-term value creation. The firm was founded and is run by Nathan Benaich, solo General Partner. 
+                            We back companies for which advances in artificial intelligence are the primary driver of product capability, competitive advantage, and long-term value creation. The firm was founded and is run by Nathan Benaich, solo General Partner.
                         </p>
 
                         <p class="copy">
                             Air Street Capital invests globally, with a focus on Europe and the United States, and works with founders building frontier AI systems, infrastructure, and applications that are technically differentiated and research-driven from day one.
                         </p>
 
-                        <br>
-
-                        <h3>What we invest in</h3>
+                        <h2>What we invest in</h2>
 
                         <p class="copy">
                             Air Street Capital invests in AI-first companies across sectors where artificial intelligence is central to the product and business model, including:
@@ -277,17 +274,13 @@
                             <li>TechBio and AI-native life sciences</li>
                         </ul>
 
-                        <br>
-
-                        <h3>Stage and approach</h3>
+                        <h2>Stage and approach</h2>
 
                         <p class="copy">
                             Air Street Capital primarily invests at the pre-seed and seed stages and often works with companies at their earliest institutional financing. Air Street Capital is known for deep engagement on product, technical strategy, and market positioning, particularly where companies are navigating rapid advances in AI capability. Air Street Capital selectively makes growth-stage investments into category leading AI-first companies.
                         </p>
 
-                        <br>
-
-                        <h3>What makes Air Street Capital distinctive</h3>
+                        <h2>What makes Air Street Capital distinctive</h2>
 
                         <p class="copy">
                             Air Street Capital is closely coupled to the frontier of AI research and industry. Air Street Capital is best known for publishing the
@@ -299,9 +292,7 @@
                             This research orientation informs Air Street Capital’s investment approach, enabling Air Street Capital to identify emerging technical inflection points, structural shifts in the AI ecosystem, and second-order effects that shape long-term outcomes for AI-first companies.
                         </p>
 
-                        <br>
-
-                        <h3>Proof of authority</h3>
+                        <h2>Proof of authority</h2>
 
                         <p class="copy">
                             Air Street Capital’s work is widely cited by policymakers, researchers, investors, and media organizations. The State of AI Report and related analysis have been referenced by outlets including the Financial Times, The Economist, Bloomberg, MIT Technology Review, Fortune, and leading academic and policy institutions.
@@ -311,9 +302,7 @@
                             The Air Street Capital portfolio includes a concentrated set of AI-first companies spanning frontier research, infrastructure, autonomy, and applied AI, reflecting a long-term, systems-level view of how artificial intelligence reshapes markets and power.
                         </p>
 
-                        <br>
-
-                        <h3>Relationship to Air Street Press</h3>
+                        <h2>Relationship to Air Street Press</h2>
 
                         <p class="copy">
                             Air Street Capital publishes ongoing analysis through
@@ -321,93 +310,87 @@
                             which features essays and analysis on AI research, markets, geopolitics, and company-building. The <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a> serves as an annual synthesis, while Air Street Press provides continuous insight throughout the year.
                         </p>
 
-                        <br>
-
-                        <h3>Examples of AI-first companies backed by Air Street Capital</h3>
+                        <h2>Examples of AI-first companies backed by Air Street Capital</h2>
 
                         <p class="copy">
                         Air Street Capital has backed a concentrated set of AI-first companies operating at the frontier of research, infrastructure, autonomy, and applied AI. Examples include:
                         </p>
 
                         <ul class="copy">
-                          <li><strong>poolside</strong> — enterprise AI for software engineering</li>
-                          <li><strong>Profluent</strong> — programmable biology and protein language models</li>
-                          <li><strong>Delian AI</strong> — autonomous defense systems</li>
-                          <li><strong>ElevenLabs</strong> — generative AI for voice and audio</li>
-                          <li><strong>Synthesia</strong> — enterprise-grade AI video platform</li>
+                          <li><strong>poolside</strong>: enterprise AI for software engineering</li>
+                          <li><strong>Profluent</strong>: programmable biology and protein language models</li>
+                          <li><strong>Delian AI</strong>: autonomous defense systems</li>
+                          <li><strong>ElevenLabs</strong>: generative AI for voice and audio</li>
+                          <li><strong>Synthesia</strong>: enterprise-grade AI video platform</li>
                         </ul>
 
                         <p class="copy">
                         A full list of investments is available on the <a href="/portfolio">portfolio</a> page.
                         </p>
 
-                        <br>
+                        <h2>Frequently asked questions</h2>
 
-                        <h3>Frequently asked questions</h3>
+                        <div class="faq-item">
+                            <h3>What is an AI-first company?</h3>
+                            <p class="copy">An AI-first company is one where advances in artificial intelligence are the primary driver of product capability, competitive advantage, and long-term value creation. In these companies, AI is not a feature layered on top of existing software, but the core technology shaping what the product can do. If the AI is removed from the product, the customer or user doesn’t use the product.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>What is an AI-first company?</strong><br>
-                        An AI-first company is one where advances in artificial intelligence are the primary driver of product capability, competitive advantage, and long-term value creation. In these companies, AI is not a feature layered on top of existing software, but the core technology shaping what the product can do. If the AI is removed from the product, the customer or user doesn't use the product.
-                        </p>
+                        <div class="faq-item">
+                            <h3>What stages does Air Street Capital invest in?</h3>
+                            <p class="copy">Air Street Capital primarily invests at the pre-seed and seed stages and often works with companies at their earliest institutional financing. The firm occasionally invests at later stages when a company’s technical trajectory aligns closely with emerging AI capabilities.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>What stages does Air Street Capital invest in?</strong><br>
-                        Air Street Capital primarily invests at the pre-seed and seed stages and often works with companies at their earliest institutional financing. The firm occasionally invests at later stages when a company’s technical trajectory aligns closely with emerging AI capabilities.
-                        </p>
+                        <div class="faq-item">
+                            <h3>Does Air Street Capital invest outside Europe?</h3>
+                            <p class="copy">Yes. Air Street Capital invests globally, with a focus on Europe and the United States. The firm works with founders wherever leading AI research, infrastructure, and company-building are taking place.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>Does Air Street Capital invest outside Europe?</strong><br>
-                        Yes. Air Street Capital invests globally, with a focus on Europe and the United States. The firm works with founders wherever leading AI research, infrastructure, and company-building are taking place.
-                        </p>
+                        <div class="faq-item">
+                            <h3>What types of AI companies does Air Street Capital focus on?</h3>
+                            <p class="copy">Air Street Capital focuses on AI-first companies across frontier model development, AI infrastructure and tooling, autonomous systems, robotics, and defense technology, AI agents and reasoning-based software, and TechBio and AI-native life sciences.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>What types of AI companies does Air Street Capital focus on?</strong><br>
-                        Air Street Capital focuses on AI-first companies across frontier model development, AI infrastructure and tooling, autonomous systems, robotics, and defense technology, AI agents and reasoning-based software, and TechBio and AI-native life sciences.
-                        </p>
+                        <div class="faq-item">
+                            <h3>How is Air Street Capital different from other AI venture capital firms?</h3>
+                            <p class="copy">Air Street Capital is deeply coupled to the frontier of AI research and industry. The firm publishes the <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a>, an independent annual analysis of global AI progress, which informs its long-term investment perspective and technical judgment.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>How is Air Street Capital different from other AI venture capital firms?</strong><br>
-                        Air Street Capital is deeply coupled to the frontier of AI research and industry. The firm publishes the <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a>, an independent annual analysis of global AI progress, which informs its long-term investment perspective and technical judgment.
-                        </p>
+                        <div class="faq-item">
+                            <h3>Is Air Street Capital affiliated with Air Street Press?</h3>
+                            <p class="copy">Yes. Air Street Capital publishes ongoing analysis through <a href="https://press.airstreet.com" target="_blank" rel="noopener noreferrer">Air Street Press</a>, which features essays and commentary on AI research, markets, geopolitics, and company-building. The State of AI Report serves as an annual synthesis, while Air Street Press provides continuous insight throughout the year.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>Is Air Street Capital affiliated with Air Street Press?</strong><br>
-                        Yes. Air Street Capital publishes ongoing analysis through <a href="https://press.airstreet.com" target="_blank" rel="noopener noreferrer">Air Street Press</a>, which features essays and commentary on AI research, markets, geopolitics, and company-building. The State of AI Report serves as an annual synthesis, while Air Street Press provides continuous insight throughout the year.
-                        </p>
+                        <div class="faq-item">
+                            <h3>How do I pitch Air Street Capital?</h3>
+                            <p class="copy">The best way to reach Air Street Capital is to email Nathan Benaich directly at <a href="mailto:nathan@airstreet.com">nathan@airstreet.com</a>. Include a brief description of the company, the AI capability at the core of the product, and the stage of the business. Air Street Capital responds to all credible inbound from founders building AI-first companies.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>How do I pitch Air Street Capital?</strong><br>
-                        The best way to reach Air Street Capital is to email Nathan Benaich directly at nathan@airstreet.com. Include a brief description of the company, the AI capability at the core of the product, and the stage of the business. Air Street Capital responds to all credible inbound from founders building AI-first companies.
-                        </p>
+                        <div class="faq-item">
+                            <h3>What is Air Street Capital’s check size?</h3>
+                            <p class="copy">Air Street Capital invests with check sizes from $500k to $10M. At the pre-seed and seed stages, checks typically range from $500k to $5M. At Series A and beyond, the firm invests $2M to $10M. Growth-stage investments are made selectively into category-leading AI-first companies.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>What is Air Street Capital’s check size?</strong><br>
-                        Air Street Capital invests with check sizes from $500k to $10M. At the pre-seed and seed stages, checks typically range from $500k to $5M. At Series A and beyond, the firm invests $2M to $10M. Growth-stage investments are made selectively into category-leading AI-first companies.
-                        </p>
+                        <div class="faq-item">
+                            <h3>What is the State of AI Report?</h3>
+                            <p class="copy">The <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a> is an annual open-access report on global AI progress across research, industry, geopolitics, and safety. First published in 2018 by Nathan Benaich and Ian Hogarth, it is the most widely read and trusted independent analysis of the AI landscape.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>What is the State of AI Report?</strong><br>
-                        The <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a> is an annual open-access report on global AI progress across research, industry, geopolitics, and safety. First published in 2018 by Nathan Benaich and Ian Hogarth, it is the most widely read and trusted independent analysis of the AI landscape.
-                        </p>
+                        <div class="faq-item">
+                            <h3>Who is Nathan Benaich?</h3>
+                            <p class="copy">Nathan Benaich is the Founder and General Partner of Air Street Capital. He is also the author and editor of the <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a>, founder of the <a href="https://www.raais.org/" target="_blank" rel="noopener noreferrer">RAAIS Foundation</a> and the <a href="https://raais.co" target="_blank" rel="noopener noreferrer">Research and Applied AI Summit (RAAIS)</a>, and founder of Spinout.fyi. His work is widely cited by the Financial Times, The Economist, Bloomberg, MIT Technology Review, and Fortune.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>Who is Nathan Benaich?</strong><br>
-                        Nathan Benaich is the Founder and General Partner of Air Street Capital. He is also the author and editor of the <a href="https://www.stateof.ai" target="_blank" rel="noopener noreferrer">State of AI Report</a>, founder of the <a href="https://www.raais.org/" target="_blank" rel="noopener noreferrer">RAAIS Foundation</a> and the <a href="https://raais.co" target="_blank" rel="noopener noreferrer">Research and Applied AI Summit (RAAIS)</a>, and founder of Spinout.fyi. His work is widely cited by the Financial Times, The Economist, Bloomberg, MIT Technology Review, and Fortune.
-                        </p>
+                        <div class="faq-item">
+                            <h3>What are Air Street Capital’s notable exits and investments?</h3>
+                            <p class="copy">Air Street Capital has backed over 60 AI-first companies. Notable portfolio outcomes include Graphcore (acquired by SoftBank), Adept (acquired by Amazon), Exscientia (NASDAQ: EXAI), Recursion (NASDAQ: RXRX), Mapillary (acquired by Meta), Jukedeck (acquired by ByteDance), and Ravelin (acquired by Worldpay). Notable portfolio companies include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, poolside, PolyAI, Chroma, and Stripe.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>What are Air Street Capital’s notable exits and investments?</strong><br>
-                        Air Street Capital has backed over 60 AI-first companies. Notable portfolio outcomes include Graphcore (acquired by SoftBank), Adept (acquired by Amazon), Exscientia (NASDAQ: EXAI), Recursion (NASDAQ: RXRX), Mapillary (acquired by Meta), Jukedeck (acquired by ByteDance), and Ravelin (acquired by Worldpay). Notable portfolio companies include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, poolside, PolyAI, Chroma, and Stripe.
-                        </p>
+                        <div class="faq-item">
+                            <h3>Does Air Street Capital lead rounds?</h3>
+                            <p class="copy">Air Street Capital invests at the pre-seed and seed stages and often works with companies at their earliest institutional financing. The firm is known for deep engagement on product, technical strategy, and market positioning from day one, and can participate as a lead or co-lead investor at the earliest stages.</p>
+                        </div>
 
-                        <p class="copy">
-                        <strong>Does Air Street Capital lead rounds?</strong><br>
-                        Air Street Capital invests at the pre-seed and seed stages and often works with companies at their earliest institutional financing. The firm is known for deep engagement on product, technical strategy, and market positioning from day one, and can participate as a lead or co-lead investor at the earliest stages.
-                        </p>
-
-                        <br>
-
-                        <p class="copy">
+                        <p class="copy closing">
                             Learn more about Air Street Capital’s investments on the <a href="/portfolio">portfolio</a> page or the people behind Air Street Capital on the <a href="/team">team</a> page.
                         </p>
 

--- a/events-llm.html
+++ b/events-llm.html
@@ -142,7 +142,7 @@
             <br>
           </div> -->
 
-            <div class="container has-text portfolio">
+            <div class="container portfolio longform">
                 <h3>Air Street Capital Events</h3>
 
   <p>Air Street Capital and Nathan Benaich runs AI events around the world including:</p>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
             <br>
           </div> -->
                 <div class="tile is-parent-homepage">
-                    <article class="tile is-child box">
+                    <article class="tile is-child box home-intro">
                         <p class="role">>_ Air Street Capital is a venture capital firm investing in AI-first companies.</p>
                         <p class="role">>_ We invest as early as possible and enjoy iterating through product, market and technology strategy from day 1.</p>
                         <p class="role">>_ Our common goal is to create enduring companies that make a lasting impact on their markets.</p>

--- a/main.css
+++ b/main.css
@@ -1,22 +1,11 @@
-/* Increase padding for button container on mobile */
-@media (max-width: 768px) {
-  .button-container {
-    padding: 1px;
-  }
-}
-
 /* Increase spacing between buttons */
 .button {
   margin: 3px;
-  padding: px px;
 }
 
-/* Additional mobile-specific adjustments */
 @media (max-width: 768px) {
   .button {
     margin: 3px;
-    padding: px px;
-    width: calc(% - 30px); /* Make buttons take up half the width minus margins */
     display: inline-block;
   }
 }
@@ -33,7 +22,6 @@ body {
 
 .announcement {
     background-color: #FFFFFF !important;
-    position: center;
     text-align: center;
     padding: 10px 5px;
     top: 0px;
@@ -79,7 +67,6 @@ body {
 .card {
     background-color: #010061ff !important;
     box-shadow: none;
-    box-sizing: 256px 256px;
 }
 
 .image {
@@ -98,14 +85,11 @@ body {
 .name {
     padding-top: 0.3rem;
     font-size: 1.15rem;
-    font-weight: 1rem;
     color: #000000;
-    font-size-adjust: 100%;
 }
 
 .role {
     font-size: 1.05rem;
-    font-weight: 1rem;
     color: #000000;
 }
 
@@ -116,7 +100,7 @@ body {
 
 .box2 {
     background-color: #010061ff;
-    box-shadow: #010061ff;
+    box-shadow: none;
 }
 
 h1, h3 {
@@ -168,23 +152,12 @@ ul {
     list-style-type: disc;
 }
 
-ul {
-    font-size: 1.1rem;
-    padding-left: 1rem;
-    list-style-position: outside;
-    list-style-type: disc;
-}
-
 a {
     text-decoration-line: underline;
 }
 
 div.header-buttons a {
     text-decoration-line: none;
-}
-
-div.portfolio ul li a {
-    font-weight: bold;
 }
 
 div.portfolio ul li a {
@@ -232,5 +205,269 @@ div.portfolio ul li a {
 @media screen and (max-width: 1100px) {
     .centered {
         width: 250px;
+    }
+}
+
+
+/* Homepage intro card: the three `>_` lines otherwise sit flush against each
+   other, because nothing gives <p> a bottom margin outside Bulma's .content. */
+.home-intro {
+    padding: 1.5rem 1.5rem 1.25rem;
+}
+
+.home-intro p {
+    margin-bottom: 0.7rem;
+}
+
+.home-intro p:last-child {
+    margin-bottom: 0;
+}
+
+
+/* ==========================================================================
+   LONG-FORM ARTICLE PAGES
+   Opt in with a single class="longform" on the element wrapping the article
+   body. Self-contained: it supplies its own card, column width and margins, so
+   it works whether the wrapper is a Bulma .tile/.box or a plain .container.
+   Everything is scoped to .longform so no other page sharing main.css moves.
+   Must stay at the end of the file: several rules deliberately override the
+   centered .container / .box defaults above at equal specificity.
+   ========================================================================== */
+
+.longform {
+    max-width: 720px;
+    margin: 2.5rem auto 3.5rem;
+    background-color: #ffffff;
+    box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.06);
+    text-align: left;
+    padding: 2.25rem 2.5rem 2.5rem;
+    border-radius: 6px;
+    color: #2c2c33;
+    font-size: 1.0625rem;
+    line-height: 1.65;
+    /* Long URLs and run-together strings must not push the card past its
+       column on narrow screens. */
+    overflow-wrap: break-word;
+}
+
+.longform h1,
+.longform h2,
+.longform h3 {
+    text-align: left;
+    padding-bottom: 0;
+    color: #010061;
+}
+
+.longform h1 {
+    font-size: 2rem;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    margin: 0 0 1.25rem;
+}
+
+.longform h2 {
+    font-size: 1.375rem;
+    line-height: 1.3;
+    margin: 2.75rem 0 0.75rem;
+}
+
+.longform h3 {
+    font-size: 1.0625rem;
+    line-height: 1.4;
+    margin: 1.75rem 0 0.4rem;
+    color: #1a1a2e;
+}
+
+/* Defensive: pages authored with Bulma's .title/.subtitle helpers sit inside
+   `.hero.is-info`, which paints titles white at (0,3,0) — invisible on the
+   card. These selectors reach (0,3,1) so the card can never swallow a heading,
+   and they hold every long-form page on one type scale. */
+.hero .longform h1.title,
+.hero .longform h1.subtitle {
+    font-size: 2rem;
+    margin: 0 0 1.25rem;
+    color: #010061;
+}
+
+.hero .longform h2.title,
+.hero .longform h2.subtitle {
+    font-size: 1.375rem;
+    margin: 2.75rem 0 0.75rem;
+    color: #010061;
+}
+
+.hero .longform h3.title,
+.hero .longform h3.subtitle {
+    font-size: 1.0625rem;
+    margin: 1.75rem 0 0.4rem;
+    color: #1a1a2e;
+}
+
+/* Same trap for body text: .hero.is-info sets a white color that would make
+   ordinary copy vanish against the white card. */
+.hero .longform,
+.hero .longform p,
+.hero .longform li {
+    color: #2c2c33;
+}
+
+.longform p {
+    text-align: left;
+    margin: 0 0 1.15rem;
+}
+
+.longform .lead {
+    font-size: 1.1875rem;
+    line-height: 1.55;
+    color: #1a1a2e;
+    margin-bottom: 1.35rem;
+}
+
+.longform ul,
+.longform ol {
+    display: block;
+    text-align: left;
+    font-size: inherit;
+    margin: 0 0 1.15rem;
+    padding-left: 1.5rem;
+    list-style-position: outside;
+}
+
+.longform ul {
+    list-style-type: disc;
+}
+
+.longform ol {
+    list-style-type: decimal;
+}
+
+.longform li {
+    text-align: left;
+    padding: 0;
+    margin-bottom: 0.4rem;
+}
+
+.longform li:last-child {
+    margin-bottom: 0;
+}
+
+.longform li > ul,
+.longform li > ol {
+    margin: 0.4rem 0 0;
+}
+
+.longform hr {
+    height: 1px;
+    background-color: #e7e7ef;
+    border: 0;
+    margin: 2rem 0;
+}
+
+.longform table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 1.15rem;
+    font-size: 0.9375rem;
+}
+
+.longform th,
+.longform td {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid #e7e7ef;
+    vertical-align: top;
+}
+
+.longform th {
+    font-weight: 700;
+    color: #010061;
+}
+
+.longform blockquote {
+    margin: 0 0 1.15rem;
+    padding: 0.25rem 0 0.25rem 1.1rem;
+    border-left: 3px solid #d8d8e6;
+    color: #4a4a58;
+}
+
+/* Long articles can carry wide tables; never let the page scroll sideways.
+   `.hero.is-fullheight` turns .hero-body into a flex container, and a flex item
+   defaults to min-width:auto — so without these the table's min-content width
+   pushes the whole card past the viewport instead of scrolling inside it. */
+.hero-body > .container:has(.longform) {
+    min-width: 0;
+}
+
+.longform {
+    min-width: 0;
+}
+
+.longform .table-scroll {
+    overflow-x: auto;
+    max-width: 100%;
+    margin: 0 0 1.15rem;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* Scroll the table rather than crushing columns to a few characters. */
+.longform .table-scroll table {
+    min-width: 34rem;
+    margin-bottom: 0;
+}
+
+.longform a {
+    color: #010061;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    text-decoration-color: rgba(1, 0, 97, 0.4);
+}
+
+.longform a:hover {
+    color: #3a34c8;
+    text-decoration-color: currentColor;
+}
+
+/* Question + answer pairs under "Frequently asked questions" */
+.longform .faq-item {
+    border-top: 1px solid #e7e7ef;
+    padding-top: 1.15rem;
+    margin-top: 1.15rem;
+}
+
+.longform .faq-item h3 {
+    margin-top: 0;
+}
+
+.longform .faq-item p:last-child {
+    margin-bottom: 0;
+}
+
+.longform .closing {
+    margin-top: 2.25rem;
+}
+
+.longform > *:last-child {
+    margin-bottom: 0;
+}
+
+@media screen and (max-width: 768px) {
+    .longform {
+        margin: 1.75rem auto 2.5rem;
+        padding: 1.5rem 1.25rem 1.75rem;
+        font-size: 1rem;
+    }
+
+    .longform h1 {
+        font-size: 1.625rem;
+    }
+
+    .longform h2 {
+        font-size: 1.1875rem;
+        margin-top: 2.25rem;
+    }
+
+    .longform .lead {
+        font-size: 1.0625rem;
     }
 }

--- a/state-of-ai-investment-trends-2025.html
+++ b/state-of-ai-investment-trends-2025.html
@@ -185,7 +185,7 @@
             <br>
           </div> -->
 
-            <div class="container has-text portfolio">
+            <div class="container portfolio longform">
 <h1>State of AI 2025 Report: 7 Critical Investment Trends for Founders</h1>
 
 <p><strong>AI investment trends 2025</strong> are being forged in a vastly different economic, regulatory, and technological climate than even a year ago. At <em>Air Street Capital</em>, we’re seeing the most promising AI-first startups succeed not through sheer capital firepower, but by aligning with deeper structural currents across compute, compliance, and customer needs.</p>
@@ -213,9 +213,9 @@
 <li>The dispersion of AI talent beyond the Bay Area.</li>
 </ol>
 
-<p>Together, these trends reshape how teams raise capital, design defensible products, and hire elite talent. In Q1 2025 alone, AI companies raised <strong>\$59.6B—accounting for 53% of global VC deployment</strong>.</p>
+<p>Together, these trends reshape how teams raise capital, design defensible products, and hire elite talent. In Q1 2025 alone, AI companies raised <strong>$59.6B, accounting for 53% of global VC deployment</strong>.</p>
 
-<p>👉 **Skip ahead to **<strong><a href="#strategic-playbook-for-ai-first-founders">Strategic Playbook for AI-First Founders</a></strong> for immediate next steps.</p>
+<p>👉 Skip ahead to <strong><a href="#strategic-playbook-for-ai-first-founders">Strategic Playbook for AI-First Founders</a></strong> for immediate next steps.</p>
 
 <hr />
 
@@ -224,16 +224,23 @@
 <h3>Macro Shifts from 2024</h3>
 
 <ul>
-<li><strong>Funding Reset:</strong> <a href="https://carta.com/data/ai-fundraising-trends-2024/">Carta's 2024 report shows that while AI startups continue to raise larger rounds than the broader market, funding is converging toward more conservative benchmarks</a>. The median AI seed round was <strong>\$3.3M</strong>, compared to <strong>\$2.5M</strong> for non-AI startups. Median Series A size was <strong>\$10.2M</strong> for AI startups (vs. <strong>\$8.6M</strong> overall), and median pre-money valuation stood at <strong>\$37M</strong>, down from peaks of <strong>\$60M+</strong> in 2021–2022. The shift reflects a broader investor pivot to milestone-based capital allocation and disciplined burn management.</li>
+<li><strong>Funding Reset:</strong> <a href="https://carta.com/data/ai-fundraising-trends-2024/">Carta's 2024 report shows that while AI startups continue to raise larger rounds than the broader market, funding is converging toward more conservative benchmarks</a>. The median AI seed round was <strong>$3.3M</strong>, compared to <strong>$2.5M</strong> for non-AI startups. Median Series A size was <strong>$10.2M</strong> for AI startups (vs. <strong>$8.6M</strong> overall), and median pre-money valuation stood at <strong>$37M</strong>, down from peaks of <strong>$60M+</strong> in 2021–2022. The shift reflects a broader investor pivot to milestone-based capital allocation and disciplined burn management.</li>
 <li><strong>Regulatory Wave:</strong> From the <strong>EU AI Act’s audit provisions</strong> to <strong>U.S. executive orders on AI oversight</strong>, founders must now treat compliance as an operational priority.</li>
 <li><strong>Enterprise Demand:</strong> Top-spending sectors include <strong>healthcare, finance, and media</strong>, where AI adoption is accelerating amid clearer ROI paths.</li>
 </ul>
 
-<p>| Factor               | 2024                     | 2025                       |   |
-| -------------------- | ------------------------ | -------------------------- | - |
-| Median Seed Round    | \$4.5M+ (peak)           | \$3.3M (Carta)             |   |
-| Series A Pre-Money   | \$60M+                   | \$37M (Carta)              |   |
-| Sector Funding Share | Generalist LLMs dominate | 68% focused on vertical AI |   |</p>
+<div class="table-scroll">
+<table>
+    <thead>
+        <tr><th>Factor</th><th>2024</th><th>2025</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Median Seed Round</td><td>$4.5M+ (peak)</td><td>$3.3M (Carta)</td></tr>
+        <tr><td>Series A Pre-Money</td><td>$60M+</td><td>$37M (Carta)</td></tr>
+        <tr><td>Sector Funding Share</td><td>Generalist LLMs dominate</td><td>68% focused on vertical AI</td></tr>
+    </tbody>
+</table>
+</div>
 
 <hr />
 
@@ -254,15 +261,62 @@
 
 <p>These seven trends are <strong>mutually reinforcing</strong>, creating a new playbook for AI-first execution.</p>
 
-<p>| Trend                | Core Idea                             | Proof Point                                    | Action                                   |
-| -------------------- | ------------------------------------- | ---------------------------------------------- | ---------------------------------------- |
-| Funding Discipline   | Smaller, milestone-driven rounds      | Median AI Series A down 30% YoY                | Calibrate burn to 18–24 mo               |
-| Vertical AI          | Domain-specific + proprietary data    | 68% of funded AI startups in 2025 are vertical | Partner for exclusive datasets           |
-| Agentic Workflows    | Autonomous, multi-step task execution | ROI uplift vs RPA exceeds 4× in pilot settings | Build with APIs + HITL                   |
-| Custom Silicon       | Alleviating compute shortages         | GB200 + H200 reshaping training timelines      | Adopt chip-agnostic architectures        |
-| Compliance-by-Design | Regulation built in from day 1        | SOC 2 / NIST frameworks favored by buyers      | Track data lineage, monitor models       |
-| Governance Layers    | Model behavior safeguards             | Only 1% of enterprises fully mature in AI ops  | Red-teaming and audit logs go mainstream |
-| Global Talent Hubs   | Talent decentralization               | Salaries 30–50% lower vs SF, similar skill     | Offer remote-first + equity upside       |</p>
+<div class="table-scroll">
+    <table>
+      <thead>
+        <tr>
+          <th>Trend</th>
+          <th>Core Idea</th>
+          <th>Proof Point</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Funding Discipline</td>
+          <td>Smaller, milestone-driven rounds</td>
+          <td>Median AI Series A down 30% YoY</td>
+          <td>Calibrate burn to 18–24 mo</td>
+        </tr>
+        <tr>
+          <td>Vertical AI</td>
+          <td>Domain-specific + proprietary data</td>
+          <td>68% of funded AI startups in 2025 are vertical</td>
+          <td>Partner for exclusive datasets</td>
+        </tr>
+        <tr>
+          <td>Agentic Workflows</td>
+          <td>Autonomous, multi-step task execution</td>
+          <td>ROI uplift vs RPA exceeds 4× in pilot settings</td>
+          <td>Build with APIs + HITL</td>
+        </tr>
+        <tr>
+          <td>Custom Silicon</td>
+          <td>Alleviating compute shortages</td>
+          <td>GB200 + H200 reshaping training timelines</td>
+          <td>Adopt chip-agnostic architectures</td>
+        </tr>
+        <tr>
+          <td>Compliance-by-Design</td>
+          <td>Regulation built in from day 1</td>
+          <td>SOC 2 / NIST frameworks favored by buyers</td>
+          <td>Track data lineage, monitor models</td>
+        </tr>
+        <tr>
+          <td>Governance Layers</td>
+          <td>Model behavior safeguards</td>
+          <td>Only 1% of enterprises fully mature in AI ops</td>
+          <td>Red-teaming and audit logs go mainstream</td>
+        </tr>
+        <tr>
+          <td>Global Talent Hubs</td>
+          <td>Talent decentralization</td>
+          <td>Salaries 30–50% lower vs SF, similar skill</td>
+          <td>Offer remote-first + equity upside</td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
 
 <hr />
 
@@ -288,12 +342,39 @@
 
 <h3>Building Multilayer Defensibility</h3>
 
-<p>| Layer                | Description                    | Example                                  |
-| -------------------- | ------------------------------ | ---------------------------------------- |
-| Proprietary data     | Unique domain-specific corpora | Microscopy image dataset                 |
-| Specialized model    | Tuned for edge-cases           | Molecular binding predictor              |
-| Workflow integration | APIs + dashboards              | LIMS or Salesforce plug-ins              |
-| Brand &amp; community    | Trust, recognition             | Founder-led papers, open-source releases |</p>
+<div class="table-scroll">
+    <table>
+      <thead>
+        <tr>
+          <th>Layer</th>
+          <th>Description</th>
+          <th>Example</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Proprietary data</td>
+          <td>Unique domain-specific corpora</td>
+          <td>Microscopy image dataset</td>
+        </tr>
+        <tr>
+          <td>Specialized model</td>
+          <td>Tuned for edge-cases</td>
+          <td>Molecular binding predictor</td>
+        </tr>
+        <tr>
+          <td>Workflow integration</td>
+          <td>APIs + dashboards</td>
+          <td>LIMS or Salesforce plug-ins</td>
+        </tr>
+        <tr>
+          <td>Brand &amp; community</td>
+          <td>Trust, recognition</td>
+          <td>Founder-led papers, open-source releases</td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
 
 <p>🧰 <strong>Defensibility Scorecard:</strong> Rate each layer 1–5 and aim for total ≥ 15.</p>
 
@@ -348,7 +429,7 @@ A: Toronto, Paris, and London—combine with equity, remote-first, and academia 
 
 <h2>Air Street Capital’s Outlook And Partnership Thesis</h2>
 
-<p>At Air Street Capital, we back ** founders** who build <strong>AI-first companies</strong>.</p>
+<p>At Air Street Capital, we back <strong>founders</strong> who build <strong>AI-first companies</strong>.</p>
 
 <p>Our portfolio includes pioneers like <strong>Profluent</strong>, <strong>Wayve</strong>, <strong>Recursion</strong>, <strong>Synthesia</strong> and <strong>ElevenLabs</strong>—companies that exemplify long-term defensibility through technical innovation and market execution.</p>
 
@@ -356,7 +437,7 @@ A: Toronto, Paris, and London—combine with equity, remote-first, and academia 
 
 <ul>
 <li><strong>Deep technical diligence</strong></li>
-<li>**Communications and marketing **<strong>expertise</strong></li>
+<li><strong>Communications and marketing expertise</strong></li>
 <li><strong>Access to a global talent network</strong></li>
 <li><strong>Strategic go-to-market support</strong></li>
 </ul>

--- a/state-of-ai-report.html
+++ b/state-of-ai-report.html
@@ -160,7 +160,7 @@
             <br>
           </div> -->
 
-            <div class="container has-text portfolio">
+            <div class="container portfolio longform">
                 <h1>State of AI Report</h1>
 
   <p>The State of AI Report analyses the most interesting developments in AI. We aim to trigger an informed conversation about the state of AI and its implication for the future. The Report is produced by AI investor Nathan Benaich and Air Street Capital. The State of AI Report is reviewed by leading AI practioners in industry and research. It considers the following key dimensions:

--- a/the-ultimate-guide-to-top-ai-venture-capital-firms-2025.html
+++ b/the-ultimate-guide-to-top-ai-venture-capital-firms-2025.html
@@ -198,7 +198,7 @@
                     <p class="copy">Air Street Capital is a venture capital firm investing in AI-first technology and life science companies in Europe and the US. We invest as early as possible and enjoy iterating through product, market and technology strategy from day 0. Our common goal is to create enduring companies that make a lasting impact on their markets.</p>
             <br>
           </div> -->
-     <div class="container has-text portfolio">
+     <div class="container portfolio longform">
       <h1>
        The Ultimate Guide to Top AI Venture Capital Firms in 2025
       </h1>
@@ -348,9 +348,18 @@
       <p>
        The AI stack consists of three interconnected layers:
       </p>
-      <p>
-       LayerComponentsExamplesModelFoundation models, fine-tunes, domain-specific modelsGPT-4, Claude, LlamaInfrastructureCompute, memory, data pipelines, vector databases, orchestrationAWS, Pinecone, LangChainApplicationVertical copilots, autonomous agents, embedded AI featuresGitHub Copilot, Jasper, Notion AI
-      </p>
+      <div class="table-scroll">
+       <table>
+        <thead>
+         <tr><th>Layer</th><th>Components</th><th>Examples</th></tr>
+        </thead>
+        <tbody>
+         <tr><td>Model</td><td>Foundation models, fine-tunes, domain-specific models</td><td>GPT-4, Claude, Llama</td></tr>
+         <tr><td>Infrastructure</td><td>Compute, memory, data pipelines, vector databases, orchestration</td><td>AWS, Pinecone, LangChain</td></tr>
+         <tr><td>Application</td><td>Vertical copilots, autonomous agents, embedded AI features</td><td>GitHub Copilot, Jasper, Notion AI</td></tr>
+        </tbody>
+       </table>
+      </div>
       <p>
        <strong>
         Key terms:

--- a/ultimate-guide-solo-gp-funds-in-venture-capital-2025.html
+++ b/ultimate-guide-solo-gp-funds-in-venture-capital-2025.html
@@ -198,7 +198,7 @@
                     <p class="copy">Air Street Capital is a venture capital firm investing in AI-first technology and life science companies in Europe and the US. We invest as early as possible and enjoy iterating through product, market and technology strategy from day 0. Our common goal is to create enduring companies that make a lasting impact on their markets.</p>
             <br>
           </div> -->
-     <div class="container has-text portfolio">
+     <div class="container portfolio longform">
       <h1>
        The Ultimate Guide to Solo GP Funds in Venture Capital for 2025
       </h1>


### PR DESCRIPTION
## What was wrong

The article pages inherited `.container { text-align: center }`, so every paragraph ran ragged on both edges, and nothing gave `<p>` a bottom margin outside Bulma's `.content`, so paragraphs butted straight into each other.

On the eight pages without a card it was worse: white copy on navy with `<h2>` computing to 16px, identical to body text, which left section headings indistinguishable from prose.

## What this does

Adds a self-contained `.longform` class carrying its own card, 720px column, type scale and rhythm, and opts the nine article pages into it. It supplies its own width and margins, so it works on a Bulma `.tile`/`.box` or a plain `.container`.

Alongside that:

- Promotes section headings to `h2` so the outline no longer skips a level, and rebuilds the ai-venture-capital FAQ as `h3` + `<p>` in divided blocks, matching the FAQPage schema the page already ships.
- Drops the 20 `<br>` tags used as spacing, including an invalid `<br></br>`.
- Strips the Bulma `.title` classes from the playbook page. `.hero.is-info .title` paints white at (0,3,0), which is invisible against the new card. A defensive rule keeps the card from ever swallowing a heading.
- Repairs three tables that had collapsed into prose: raw markdown pipe rows on state-of-ai-investment-trends, plus 12-best and the-ultimate-guide each carrying a table flattened into a single run-on line. That same page also had 11 escaped `\$` and 6 stray `**` rendering literally.
- Gives tables a scroll container. `.hero.is-fullheight` makes `.hero-body` a flex container, and a flex item will not shrink below min-content, so a wide table pushed the card past the viewport instead of scrolling inside it.
- Spaces the three lines in the homepage intro card, which had the same zero-margin bug.
- Removes six CSS declarations the browser was already discarding as invalid (`padding: px px`, `calc(% - 30px)`, `box-sizing: 256px 256px`, `position: center`, `box-shadow: #010061ff`, `font-weight: 1rem`), two duplicated rule blocks, and a `.button-container` selector matching nothing in the repo.

## Scope

`main.css` is shared by 45 pages, so every new rule is scoped to `.longform` or `.home-intro`. The invalid declarations removed were already being dropped by the parser, and `.box2` is never combined with `.box`, so those are no-ops. teamOLD.html is a deprecated team grid and index.html is a short hero blurb, so neither took the article treatment.

## Verification

Measured at 1280px and 375px across all ten pages: no centered body copy, no horizontal overflow, uniform 32/22/17px type scale, and all 1,483 text elements inside the cards pass a luminance check against white.

## Worth a look before merging

Two of the tables were reconstructed from run-on text: the 12-firm comparison on `12-best-ai-venture-capital-firms` and the AI-stack table on `the-ultimate-guide-to-top-ai-venture-capital-firms-2025`. The cell boundaries were unambiguous, but the check sizes and stage focuses are your figures, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)