### PR TITLE
Refresh the featured companies list and capitalize Poolside

### DIFF
--- a/ai-venture-capital.html
+++ b/ai-venture-capital.html
@@ -160,7 +160,7 @@
           "name": "What are Air Street Capital’s notable exits and investments?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Air Street Capital has backed over 60 AI-first companies. Notable portfolio outcomes include Graphcore (acquired by SoftBank), Adept (acquired by Amazon), Exscientia (NASDAQ: EXAI), Recursion (NASDAQ: RXRX), Mapillary (acquired by Meta), Jukedeck (acquired by ByteDance), and Ravelin (acquired by Worldpay). Notable portfolio companies include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, poolside, PolyAI, Chroma, and Stripe."
+            "text": "Air Street Capital has backed over 60 AI-first companies. Notable portfolio outcomes include Graphcore (acquired by SoftBank), Adept (acquired by Amazon), Exscientia (NASDAQ: EXAI), Recursion (NASDAQ: RXRX), Mapillary (acquired by Meta), Jukedeck (acquired by ByteDance), and Ravelin (acquired by Worldpay). Notable portfolio companies include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, Poolside, PolyAI, Chroma, and Stripe."
           }
         },
         {
@@ -317,9 +317,13 @@
                         </p>
 
                         <ul class="copy">
-                          <li><strong>poolside</strong>: enterprise AI for software engineering</li>
+                          <li><strong>Poolside</strong>: enterprise AI for software engineering</li>
                           <li><strong>Profluent</strong>: programmable biology and protein language models</li>
-                          <li><strong>Delian AI</strong>: autonomous defense systems</li>
+                          <li><strong>STARK Defence</strong>: autonomous defense systems</li>
+                          <li><strong>Alta Ares</strong>: air defense systems</li>
+                          <li><strong>Crusoe</strong>: AI factories and cloud infrastructure</li>
+                          <li><strong>Lambda Labs</strong>: GPU cloud for AI training and inference</li>
+                          <li><strong>Recursion Pharmaceuticals</strong>: AI-driven drug discovery (NASDAQ: RXRX)</li>
                           <li><strong>ElevenLabs</strong>: generative AI for voice and audio</li>
                           <li><strong>Synthesia</strong>: enterprise-grade AI video platform</li>
                         </ul>
@@ -382,7 +386,7 @@
 
                         <div class="faq-item">
                             <h3>What are Air Street Capital’s notable exits and investments?</h3>
-                            <p class="copy">Air Street Capital has backed over 60 AI-first companies. Notable portfolio outcomes include Graphcore (acquired by SoftBank), Adept (acquired by Amazon), Exscientia (NASDAQ: EXAI), Recursion (NASDAQ: RXRX), Mapillary (acquired by Meta), Jukedeck (acquired by ByteDance), and Ravelin (acquired by Worldpay). Notable portfolio companies include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, poolside, PolyAI, Chroma, and Stripe.</p>
+                            <p class="copy">Air Street Capital has backed over 60 AI-first companies. Notable portfolio outcomes include Graphcore (acquired by SoftBank), Adept (acquired by Amazon), Exscientia (NASDAQ: EXAI), Recursion (NASDAQ: RXRX), Mapillary (acquired by Meta), Jukedeck (acquired by ByteDance), and Ravelin (acquired by Worldpay). Notable portfolio companies include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, Poolside, PolyAI, Chroma, and Stripe.</p>
                         </div>
 
                         <div class="faq-item">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -41,7 +41,7 @@ Air Street Capital invests in AI-first companies across sectors where artificial
 
 ### Epoch II (2022–present)
 
-- **poolside** — Enterprise AI for software engineering (USA). https://poolside.ai/
+- **Poolside** — Enterprise AI for software engineering (USA). https://poolside.ai/
 - **Profluent** — Programmable biology and protein language models (USA). https://www.profluent.bio/
 - **Samaya AI** — Knowledge discovery (USA). https://samaya.ai/
 - **Sereact** — Industrial robotics (Germany). https://sereact.ai/
@@ -49,7 +49,7 @@ Air Street Capital invests in AI-first companies across sectors where artificial
 - **Odyssey** — Interactive video (USA/UK). https://www.odyssey.ml/
 - **Interloom** — Enterprise automation (Germany). https://interloom.io/
 - **Patina Systems** — Spontaneous software (USA). https://patinasystems.com/
-- **Fern Labs** (acquired by poolside) — AI agents (UK). https://fern-labs.ai/
+- **Fern Labs** (acquired by Poolside) — AI agents (UK). https://fern-labs.ai/
 - **Studio Atelico** — AI game studio (USA/UK). https://atelico.studio/
 - **Polar Mist** — Maritime autonomy (EU). https://www.polarmist.ai/
 - **Delfa** — Clinical trials (USA/UK). https://www.delfa.ai/
@@ -62,7 +62,7 @@ Air Street Capital invests in AI-first companies across sectors where artificial
 - **Graphcore** (acquired by SoftBank) — AI semiconductors (UK). https://www.graphcore.ai/
 - **Exscientia** (NASDAQ: EXAI) — AI-driven pharma (UK). https://www.exscientia.ai/
 - **Recursion** (NASDAQ: RXRX) — AI-driven pharma (USA). https://www.recursion.com/
-- **poolside** — Enterprise AGI (USA). https://poolside.ai/
+- **Poolside** — Enterprise AGI (USA). https://poolside.ai/
 - **V7** — Computer vision data platform (UK). https://www.v7labs.com/
 - **ZOE** — Personalized nutrition (UK). https://joinzoe.com/
 - **Coram AI** — Video intelligence (UK/USA). https://www.coram.ai/
@@ -122,7 +122,7 @@ Air Street Capital invests in AI-first companies across sectors where artificial
 - **Allcyte** — Acquired by Exscientia
 - **Athenian** — Acquired by Linux Foundation
 - **Valence Discovery** — Acquired by Recursion
-- **Fern Labs** — Acquired by poolside
+- **Fern Labs** — Acquired by Poolside
 - **Anagenex** — Acquired
 
 ## Domains of Expertise

--- a/portfolio.html
+++ b/portfolio.html
@@ -93,7 +93,7 @@
         {"@type": "ListItem", "position": 12, "item": {"@type": "Organization", "name": "Delfa", "url": "https://www.delfa.ai/", "description": "AI for clinical trials"}},
         {"@type": "ListItem", "position": 13, "item": {"@type": "Organization", "name": "Polar Mist", "url": "https://www.polarmist.ai/", "description": "Maritime autonomy"}},
         {"@type": "ListItem", "position": 14, "item": {"@type": "Organization", "name": "Studio Atelico", "url": "https://atelico.studio/", "description": "AI game studio"}},
-        {"@type": "ListItem", "position": 15, "item": {"@type": "Organization", "name": "Fern Labs", "url": "https://fern-labs.ai/", "description": "AI agents (acquired by poolside)"}},
+        {"@type": "ListItem", "position": 15, "item": {"@type": "Organization", "name": "Fern Labs", "url": "https://fern-labs.ai/", "description": "AI agents (acquired by Poolside)"}},
         {"@type": "ListItem", "position": 16, "item": {"@type": "Organization", "name": "Patina Systems", "url": "https://patinasystems.com/", "description": "Spontaneous software"}},
         {"@type": "ListItem", "position": 17, "item": {"@type": "Organization", "name": "Interloom", "url": "https://interloom.io/", "description": "Enterprise automation"}},
         {"@type": "ListItem", "position": 18, "item": {"@type": "Organization", "name": "Odyssey", "url": "https://www.odyssey.ml/", "description": "Interactive video"}},
@@ -117,7 +117,7 @@
         {"@type": "ListItem", "position": 36, "item": {"@type": "Organization", "name": "LabGenius", "url": "https://www.labgeni.us/", "description": "Protein therapeutics"}},
         {"@type": "ListItem", "position": 37, "item": {"@type": "Organization", "name": "Mission Barns", "url": "https://missionbarns.com/", "description": "Lab-grown fat"}},
         {"@type": "ListItem", "position": 38, "item": {"@type": "Organization", "name": "Modern Intelligence", "url": "https://www.modernintelligence.ai", "description": "AI for defense"}},
-        {"@type": "ListItem", "position": 39, "item": {"@type": "Organization", "name": "poolside", "url": "https://poolside.ai/", "description": "Enterprise AI for software engineering"}},
+        {"@type": "ListItem", "position": 39, "item": {"@type": "Organization", "name": "Poolside", "url": "https://poolside.ai/", "description": "Enterprise AI for software engineering"}},
         {"@type": "ListItem", "position": 40, "item": {"@type": "Organization", "name": "Recursion", "url": "https://www.recursion.com/", "description": "AI-driven pharma (NASDAQ: RXRX)"}},
         {"@type": "ListItem", "position": 41, "item": {"@type": "Organization", "name": "Valence Discovery", "url": "https://www.valencediscovery.com/", "description": "AI-driven pharma (acquired by Recursion)"}},
         {"@type": "ListItem", "position": 42, "item": {"@type": "Organization", "name": "V7", "url": "https://www.v7labs.com/", "description": "Computer vision data platform"}},
@@ -152,8 +152,8 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>Air Street Capital｜AI venture capital for AI-first companies</title>
-    <meta name="description" content="Portfolio companies backed by Air Street Capital, a venture capital firm investing in AI-first companies across frontier AI, infrastructure, autonomy, defense, and TechBio. Notable investments include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, poolside, and Stripe.">
-    <meta name="keywords" content="AI venture capital portfolio, AI-first companies, artificial intelligence startups, AI investments, ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, poolside, Air Street Capital, Nathan Benaich">
+    <meta name="description" content="Portfolio companies backed by Air Street Capital, a venture capital firm investing in AI-first companies across frontier AI, infrastructure, autonomy, defense, and TechBio. Notable investments include ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, Poolside, and Stripe.">
+    <meta name="keywords" content="AI venture capital portfolio, AI-first companies, artificial intelligence startups, AI investments, ElevenLabs, Synthesia, Wayve, Crusoe, Lambda, Poolside, Air Street Capital, Nathan Benaich">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="canonical" href="https://www.airstreet.com/portfolio" />
     <link rel="manifest" href="site.webmanifest">
@@ -243,7 +243,7 @@
             <li><a href="https://atelico.studio/" target="_blank" rel="noopener noreferrer">Studio Atelico</a>. AI game studio (USA/UK);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Spatial magic (USA);</li>
             <li><a href="###" target="_blank" rel="noopener noreferrer">Unannounced</a>. Stealth (USA);</li>
-            <li><a href="https://fern-labs.ai/" target="_blank" rel="noopener noreferrer">Fern Labs (acq. poolside)</a>. AI agents (UK);</li>
+            <li><a href="https://fern-labs.ai/" target="_blank" rel="noopener noreferrer">Fern Labs (acq. Poolside)</a>. AI agents (UK);</li>
             <li><a href="https://patinasystems.com/" target="_blank" rel="noopener noreferrer">Patina Systems</a>. Spontaneous software (USA);</li>
             <li><a href="https://interloom.io/" target="_blank" rel="noopener noreferrer">Interloom</a>. Enterprise automation (DE);</li>
             <li><a href="https://www.odyssey.ml/" target="_blank" rel="noopener noreferrer">Odyssey</a>. Interactive video (US/UK);</li>
@@ -273,7 +273,7 @@
     <li><a href="https://www.labgeni.us/" target="_blank" rel="noopener noreferrer">LabGenius</a>. Protein therapeutics (UK);</li>
     <li><a href="https://missionbarns.com/" target="_blank" rel="noopener noreferrer">Mission Barns</a>. Lab-grown fat (USA);</li>
     <li><a href="https://www.modernintelligence.ai" target="_blank" rel="noopener noreferrer">Modern Intelligence</a>. AI for defense (USA);</li>
-    <li><a href="https://poolside.ai/" target="_blank" rel="noopener noreferrer">poolside</a>. Enterprise AGI (USA);</li>
+    <li><a href="https://poolside.ai/" target="_blank" rel="noopener noreferrer">Poolside</a>. Enterprise AGI (USA);</li>
     <li><a href="https://www.recursion.com/" target="_blank" rel="noopener noreferrer">Recursion (NASDAQ: RXRX)</a>. Pharma (USA);</li>
     <li><a href="https://www.valencediscovery.com/" target="_blank" rel="noopener noreferrer">Valence Discovery (acq. RXRX)</a>. Pharma (CA);</li>
     <li><a href="https://www.v7labs.com/" target="_blank" rel="noopener noreferrer">V7</a>. Computer vision data platform (UK);</li>


### PR DESCRIPTION
Swaps Delian AI out of the example list on the AI venture capital page for STARK Defence, Alta Ares, Crusoe, Lambda Labs, and Recursion Pharmaceuticals.

Capitalizes Poolside everywhere it appears as visible copy, schema markup, or meta tags across `ai-venture-capital.html`, `portfolio.html`, and `llms-full.txt`. The `poolside.ai` URLs are unchanged.

Delian AI still appears in the full portfolio list and in `llms-full.txt`; only the featured examples list changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)